### PR TITLE
Eliminación de un punto y coma erróneo

### DIFF
--- a/src/AppForSEII2526.API/Models/Model.cs
+++ b/src/AppForSEII2526.API/Models/Model.cs
@@ -14,7 +14,7 @@ namespace AppForSEII2526.API.Models
                        Name = name;
         }
 
-        public int Id { get; set; };
+        public int Id { get; set; }
         public string Name { get; set; }
     }
 }


### PR DESCRIPTION
En la clase Model en la linea 17 había un punto y coma que causaba un error de compilación. Ya compila.